### PR TITLE
avoid duplicate videos by updating timestamp

### DIFF
--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -70,6 +70,7 @@ function updatePlaylists() {
       }
     }
   }
+  sheet.getRange(reservedTimestampCell).setValue(ISODateString(new Date())) //to avoid adding the same videos twice, update the timestamp when script completes.
 }
 
 function getVideoIds(channelId, lastTimestamp) {


### PR DESCRIPTION
the scripts keeps adding the same videos over and over...
To let the script run every hour automatically, I update the timestamp after each run to make sure no video gets added twice to the same playlist.