### PR TITLE
Exclude error when video is already in playlist.

### DIFF
--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -118,8 +118,10 @@ function updatePlaylists(sheet) {
           );
         } catch (e) {
           Logger.log("Couldn't update playlist with video ("+videoIds[i]+"), ERROR: " + "Message: [" + e.message + "] Details: " + JSON.stringify(e.details));
+          if (e.details.code !== 409) { // Skip error count if Video exists in playlist already
+            var errorflag = true;
+          }
           errorCount += 1;
-          var errorflag = true;
           continue;
         }
 


### PR DESCRIPTION
Error 409 is the youtube error for existing items. If an item exists, it's technically an error and results in the script consistently failing.

This skips the error flag for existing items to avoid compounding errors and triggering the Timestamp update regardless of the video being in the playlist.