### PR TITLE
Bypass 200 video limit

### DIFF
--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -106,13 +106,13 @@ function updatePlaylists(sheet) {
       lastTimestamp = isodate;
     }
   
-  // Check if it's time to update already
-  var freqDate = new Date(lastTimestamp);
-  var dateDiff = Date.now() - freqDate;
-  var nextTime = data[iRow][reservedColumnFrequency]  * MILLIS_PER_HOUR;
-  if (nextTime && dateDiff <= nextTime) {
-    Logger.log("Skipped: Not time yet");
-  } else {
+    // Check if it's time to update already
+    var freqDate = new Date(lastTimestamp);
+    var dateDiff = Date.now() - freqDate;
+    var nextTime = data[iRow][reservedColumnFrequency]  * MILLIS_PER_HOUR;
+    if (nextTime && dateDiff <= nextTime) {
+      Logger.log("Skipped: Not time yet");
+    } else {
       /// ...get channels...
       var channelIds = [];
       var playlistIds = [];

--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -202,7 +202,6 @@ function updatePlaylists(sheet) {
 
 function addVideosToPlaylist(playlistId, videoIds, idx = 0, successCount = 0, errorCount = 0) {
   var totalVids = videoIds.length;
-  var success = 1;
   if (0 < totalVids && totalVids < maxVideos) {
     try {
       YouTube.PlaylistItems.insert({
@@ -214,6 +213,7 @@ function addVideosToPlaylist(playlistId, videoIds, idx = 0, successCount = 0, er
           }
       }
       }, 'snippet');
+      var success = 1;
     } catch (e) {
       if (e.details.code !== 409) { // Skip error count if Video exists in playlist already
       addError("Couldn't update playlist with video ("+videoIds[idx]+"), ERROR: " + "Message: [" + e.message + "] Details: " + JSON.stringify(e.details));

--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -232,6 +232,8 @@ function addVideosToPlaylist(playlistId, videoIds, idx = 0, successCount = 0, er
         addVideosToPlaylist(playlistId, videoIds, idx, successCount, errorCount);
       }
     }
+  } else if (totalVids == 0) {	
+    Logger.log("No new videos yet.")	
   } else {	
     addError("The query contains "+totalVids+" videos. Script cannot add more than "+maxVideos+" videos. Try moving the timestamp closer to today.")	
   }

--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -203,7 +203,7 @@ function updatePlaylists(sheet) {
 function addVideosToPlaylist(playlistId, videoIds, idx = 0, successCount = 0, errorCount = 0) {
   var totalVids = videoIds.length;
   var success = 1;
-  if (totalVids > 0) {
+  if (0 < totalVids && totalVids < maxVideos) {
     try {
       YouTube.PlaylistItems.insert({
         snippet: {
@@ -232,6 +232,8 @@ function addVideosToPlaylist(playlistId, videoIds, idx = 0, successCount = 0, er
         addVideosToPlaylist(playlistId, videoIds, idx, successCount, errorCount);
       }
     }
+  } else {	
+    addError("The query contains "+videoIds.length+" videos. Script cannot add more than "+maxVideos+" videos. Try moving the timestamp closer to today.")	
   }
 }
 

--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -216,8 +216,8 @@ function addVideosToPlaylist(playlistId, videoIds, idx = 0, successCount = 0, er
       var success = 1;
     } catch (e) {
       if (e.details.code !== 409) { // Skip error count if Video exists in playlist already
-      addError("Couldn't update playlist with video ("+videoIds[idx]+"), ERROR: " + "Message: [" + e.message + "] Details: " + JSON.stringify(e.details));
-    } else {
+        addError("Couldn't update playlist with video ("+videoIds[idx]+"), ERROR: " + "Message: [" + e.message + "] Details: " + JSON.stringify(e.details));
+      } else {
         Logger.log("Couldn't update playlist with video ("+videoIds[idx]+"), ERROR: Video already exists")
       }
       errorCount += 1;

--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -233,7 +233,7 @@ function addVideosToPlaylist(playlistId, videoIds, idx = 0, successCount = 0, er
       }
     }
   } else {	
-    addError("The query contains "+videoIds.length+" videos. Script cannot add more than "+maxVideos+" videos. Try moving the timestamp closer to today.")	
+    addError("The query contains "+totalVids+" videos. Script cannot add more than "+maxVideos+" videos. Try moving the timestamp closer to today.")	
   }
 }
 


### PR DESCRIPTION
The original implementation uses `sleep(1000)` to avoid rate limiting during the video insertion into the playlist. While we can reduce this number (100 still worked fine for me) to get more videos in, we can use recursion to let the API "take the time it needs" and then insert the next video. This is the fastest execution time possible and leaves us with possibilities to extend the code dynamically.