### PR TITLE
Delete duplicated videos

### DIFF
--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -469,6 +469,7 @@ function addVideosToPlaylist(playlistId, videoIds, idx = 0, successCount = 0, er
 // Delete Videos from Playlist if they're older than the defined time
 function deletePlaylistItems(playlistId, deleteBeforeTimestamp) {
   var nextPageToken = '';
+  var allVideos = [];
   while (nextPageToken != null){
 
     try {
@@ -479,6 +480,8 @@ function deletePlaylistItems(playlistId, deleteBeforeTimestamp) {
         publishedBefore: deleteBeforeTimestamp, // this compares the timestamp when the video was added to playlist
         pageToken: nextPageToken});
         
+      results.items.forEach(x => allVideos.push(x));
+
       for (var j = 0; j < results.items.length; j++) {
         var item = results.items[j];
         if (item.contentDetails.videoPublishedAt < deleteBeforeTimestamp) // this compares the timestamp when the video was published
@@ -494,6 +497,26 @@ function deletePlaylistItems(playlistId, deleteBeforeTimestamp) {
       addError("Problem deleting existing videos from playlist with id "+playlistId+", ERROR: " + "Message: [" + e.message + "] Details: " + JSON.stringify(e.details));
       nextPageToken = null;
     }
+  }
+
+  // Delete Duplicates Videos by videoId
+  try {
+    let tempVideos = [];
+    let duplicateVideos = [];
+
+    allVideos.forEach(x => {
+      if (tempVideos.find(y => y.contentDetails.videoId === x.contentDetails.videoId)) {
+        duplicateVideos.push(x);
+      } else {
+        tempVideos.push(x);
+      }
+    });
+
+    duplicateVideos.forEach(x => {
+      YouTube.PlaylistItems.remove(x.id);
+    });
+  } catch (e) {
+    addError("Problem deleting duplicate videos from playlist with id "+playlistId+", ERROR: " + "Message: [" + e.message + "] Details: " + JSON.stringify(e.details));
   }
 }
 

--- a/sheetScript.gs
+++ b/sheetScript.gs
@@ -480,14 +480,14 @@ function deletePlaylistItems(playlistId, deleteBeforeTimestamp) {
         publishedBefore: deleteBeforeTimestamp, // this compares the timestamp when the video was added to playlist
         pageToken: nextPageToken});
         
-      results.items.forEach(x => allVideos.push(x));
-
       for (var j = 0; j < results.items.length; j++) {
         var item = results.items[j];
         if (item.contentDetails.videoPublishedAt < deleteBeforeTimestamp) // this compares the timestamp when the video was published
         { 
           Logger.log("Del: | "+item.contentDetails.videoPublishedAt)
           YouTube.PlaylistItems.remove(item.id)
+        } else {
+          allVideos.push(item);
         }
       }
       


### PR DESCRIPTION
In some cases, when a quota error occurs, it adds some videos to the playlist but doesn't update the last run date.

This can result in duplicate videos in the destination playlist.

Change made to delete duplicate videos (comparing by videoId)
